### PR TITLE
fix: update default openrouter api url

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
-TARGET_API_BASE=https://api.openrouter.ai/v1
+TARGET_API_BASE=https://openrouter.ai/api/v1
 TARGET_API_KEY=<your_provider_key>
 BIG_MODEL_TARGET=openai/gpt-4.1
 SMALL_MODEL_TARGET=openai/gpt-4.1-mini


### PR DESCRIPTION
## Description

This PR updates the default OpenRouter API URL in the .env.example file from https://api.openrouter.ai/v1 to https://openrouter.ai/api/v1. This change ensures that users have the correct API endpoint configured by default when setting up the project.

## Motivation and Context

The previous API URL was incorrect or outdated, which would cause connection issues for new users trying to set up the project with OpenRouter. This fix ensures that the default configuration points to the correct endpoint, improving the onboarding experience.

## How Has This Been Tested?

I had to fix this for myself when first running it because every request just generated an error. I got the correct URL from https://openrouter.ai/docs/quickstart

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.